### PR TITLE
Update to latest chatterbot major version

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,10 +5,8 @@ from chatterbot.trainers import ChatterBotCorpusTrainer
 app = Flask(__name__)
 
 english_bot = ChatBot("Chatterbot", storage_adapter="chatterbot.storage.SQLStorageAdapter")
-
-english_bot.set_trainer(ChatterBotCorpusTrainer)
-english_bot.train("chatterbot.corpus.english")
-
+trainer = ChatterBotCorpusTrainer(english_bot)
+trainer.train("chatterbot.corpus.english")
 
 @app.route("/")
 def home():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Used by pip to install required python packages
 # Usage: pip install -r requirements.txt
 
-Flask>=0.11
-chatterbot>=0.7.1
-SQLAlchemy>=1.1.11
+Flask>=1.0.0
+chatterbot>=1.0.0
+SQLAlchemy>=1.3


### PR DESCRIPTION
I was trying to use this example with recent versions of chatterbot and got errors with 'set_trainer' - it looks like the latest API is changed. This change updates the requirements.txt to more recent package versions.